### PR TITLE
Speed optimizations and bounds bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 codex.tags
 hscope.out
 .DS_Store
+dist-newstyle
+cabal.project.local*

--- a/benchmark/Data/HyperLogLogPlus/Benchmarks.hs
+++ b/benchmark/Data/HyperLogLogPlus/Benchmarks.hs
@@ -5,6 +5,7 @@ module Data.HyperLogLogPlus.Benchmarks
     benchInserts
   , benchInsertsLStrict
   , benchInsertHashes
+  , benchInsertBatched
   , benchSemigroupTwo
   , benchSize
   , benchIntersect
@@ -12,6 +13,7 @@ module Data.HyperLogLogPlus.Benchmarks
   -- * Zero-minhash variants.
   , benchInserts0
   , benchInsertsLStrict0
+  , benchInsertBatched0
   , benchSemigroupTwo0
   , HLL0
   ) where
@@ -40,6 +42,10 @@ benchInsertsLStrict :: Int -> Benchmark
 benchInsertsLStrict n = bench (show n) $ nf f n
   where f n = size (foldl' (flip insert) mempty (map show [1 .. n]) :: HLL)
 
+benchInsertBatched :: Int -> Benchmark
+benchInsertBatched n = bench (show n) $ nf f n
+  where f n = size (batchInsert (map show [1 .. n]) mempty :: HLL)
+
 benchSemigroupTwo :: Int -> HLL -> HLL -> Benchmark
 benchSemigroupTwo n hll1 hll2 = bench (show n) $ nf f (hll1, hll2)
   where f :: (HLL, HLL) -> Word64
@@ -62,6 +68,10 @@ benchInserts0 n = bench (show n) $ nf f n
 benchInsertsLStrict0 :: Int -> Benchmark
 benchInsertsLStrict0 n = bench (show n) $ nf f n
   where f n = size (foldl' (flip insert) mempty (map show [1 .. n]) :: HLL0)
+
+benchInsertBatched0 :: Int -> Benchmark
+benchInsertBatched0 n = bench (show n) $ nf f n
+  where f n = size (batchInsert (map show [1 .. n]) mempty :: HLL0)
 
 benchSemigroupTwo0 :: Int -> HLL0 -> HLL0 -> Benchmark
 benchSemigroupTwo0 n hll1 hll2 = bench (show n) $ nf f (hll1, hll2)

--- a/benchmark/Data/HyperLogLogPlus/Benchmarks.hs
+++ b/benchmark/Data/HyperLogLogPlus/Benchmarks.hs
@@ -3,11 +3,17 @@
 module Data.HyperLogLogPlus.Benchmarks
   (
     benchSemigroup
+  , benchSemigroupLStrict
   , benchSize
   , benchIntersect
   , HLL
+  -- * Zero-minhash variants.
+  , benchSemigroup0
+  , benchSemigroupLStrict0
+  , HLL0
   ) where
 
+import Data.Foldable (foldl')
 import Data.HyperLogLogPlus
 import Data.Word
 import Data.Semigroup
@@ -16,10 +22,15 @@ import Criterion            (Benchmark, bench, nf, env)
 
 
 type HLL = HyperLogLogPlus 12 2048
+type HLL0 = HyperLogLogPlus 12 0
 
 benchSemigroup :: Int -> Benchmark
-benchSemigroup n =  bench (show n) $ nf f n
+benchSemigroup n = bench (show n) $ nf f n
   where f n = size (foldr insert mempty (map show [1 .. n]) :: HLL)
+
+benchSemigroupLStrict :: Int -> Benchmark
+benchSemigroupLStrict n = bench (show n) $ nf f n
+  where f n = size (foldl' (flip insert) mempty (map show [1 .. n]) :: HLL)
 
 benchSize :: Int -> HLL -> Benchmark
 benchSize n hll = bench (show n) $ nf size hll
@@ -30,3 +41,11 @@ benchIntersect :: Int -> HLL -> HLL -> Benchmark
 benchIntersect n hll1 hll2 = bench (show n) $ nf f (hll1, hll2)
   where f :: (HLL, HLL) -> Word64
         f (l, r) = intersection [l, r]
+
+benchSemigroup0 :: Int -> Benchmark
+benchSemigroup0 n = bench (show n) $ nf f n
+  where f n = size (foldr insert mempty (map show [1 .. n]) :: HLL0)
+
+benchSemigroupLStrict0 :: Int -> Benchmark
+benchSemigroupLStrict0 n = bench (show n) $ nf f n
+  where f n = size (foldl' (flip insert) mempty (map show [1 .. n]) :: HLL0)

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -5,6 +5,7 @@ module Main (main) where
 
 import qualified Data.HyperLogLogPlus.Benchmarks as B
 
+import           Data.Digest.Murmur64 (hash64)
 import           Data.Semigroup
 import           Data.HyperLogLogPlus
 
@@ -21,22 +22,42 @@ main = do
   let !hll5 = setupHLL 1 35000
   let !hll6 = setupHLL 30000 50000
 
+  let !hll03 = setupHLL0 1 7000
+  let !hll04 = setupHLL0 5000 10000
+
+  let !hll05 = setupHLL0 1 35000
+  let !hll06 = setupHLL0 30000 50000
+
+  let !hs10k = let xs = map hash64 [1..(10000::Int)] in length xs `seq` xs
+  let !hs50k = let xs = map hash64 [1..(50000::Int)] in length xs `seq` xs
+
+
   defaultMain
     [ bgroup "HLL 12 2048"
-      [ bgroup "HLL semigroup"
-        [ bgroup "foldr"  [ B.benchSemigroup 10000,           B.benchSemigroup 50000]
-        , bgroup "foldl'" [ B.benchSemigroupLStrict 10000,    B.benchSemigroupLStrict 50000]
+      [ bgroup "inserts"
+        [ bgroup "foldr"  [ B.benchInserts 10000,              B.benchInserts 50000]
+        , bgroup "foldl'" [ B.benchInsertsLStrict 10000,       B.benchInsertsLStrict 50000]
+        , bgroup "hashes" [ B.benchInsertHashes 10000 hs10k,   B.benchInsertHashes 50000 hs50k]
         ]
-      , bgroup "HLL size"      [ B.benchSize 10000 hll1,           B.benchSize 50000 hll2 ]
-      , bgroup "HLL intersect" [ B.benchIntersect 10000 hll3 hll4, B.benchIntersect 50000 hll5 hll6 ]
+      , bgroup "semigroup"
+        [ bgroup "two"    [ B.benchSemigroupTwo 10000 hll3 hll4, B.benchSemigroupTwo 50000 hll5 hll6]
+        ]
+      , bgroup "size"      [ B.benchSize 10000 hll1,           B.benchSize 50000 hll2 ]
+      , bgroup "intersect" [ B.benchIntersect 10000 hll3 hll4, B.benchIntersect 50000 hll5 hll6 ]
       ]
     , bgroup "HLL 12 0"
-      [ bgroup "HLL semigroup"
-        [ bgroup "foldr"  [ B.benchSemigroup0 10000,           B.benchSemigroup0 50000]
-        , bgroup "foldl'" [ B.benchSemigroupLStrict0 10000,    B.benchSemigroupLStrict0 50000]
+      [ bgroup "inserts"
+        [ bgroup "foldr"  [ B.benchInserts0 10000,           B.benchInserts0 50000]
+        , bgroup "foldl'" [ B.benchInsertsLStrict0 10000,    B.benchInsertsLStrict0 50000]
+        ]
+      , bgroup "semigroup"
+        [ bgroup "two"    [ B.benchSemigroupTwo0 10000 hll03 hll04, B.benchSemigroupTwo0 50000 hll05 hll06]
         ]
       ]
     ]
 
 setupHLL :: Int -> Int -> B.HLL
 setupHLL from to = foldr insert mempty (map show [from .. to])
+
+setupHLL0 :: Int -> Int -> B.HLL0
+setupHLL0 from to = foldr insert mempty (map show [from .. to])

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -22,9 +22,20 @@ main = do
   let !hll6 = setupHLL 30000 50000
 
   defaultMain
-    [ bgroup "HLL semigroup" [ B.benchSemigroup 10000,           B.benchSemigroup 50000]
-    , bgroup "HLL size"      [ B.benchSize 10000 hll1,           B.benchSize 50000 hll2 ]
-    , bgroup "HLL intersect" [ B.benchIntersect 10000 hll3 hll4, B.benchIntersect 50000 hll5 hll6 ]
+    [ bgroup "HLL 12 2048"
+      [ bgroup "HLL semigroup"
+        [ bgroup "foldr"  [ B.benchSemigroup 10000,           B.benchSemigroup 50000]
+        , bgroup "foldl'" [ B.benchSemigroupLStrict 10000,    B.benchSemigroupLStrict 50000]
+        ]
+      , bgroup "HLL size"      [ B.benchSize 10000 hll1,           B.benchSize 50000 hll2 ]
+      , bgroup "HLL intersect" [ B.benchIntersect 10000 hll3 hll4, B.benchIntersect 50000 hll5 hll6 ]
+      ]
+    , bgroup "HLL 12 0"
+      [ bgroup "HLL semigroup"
+        [ bgroup "foldr"  [ B.benchSemigroup0 10000,           B.benchSemigroup0 50000]
+        , bgroup "foldl'" [ B.benchSemigroupLStrict0 10000,    B.benchSemigroupLStrict0 50000]
+        ]
+      ]
     ]
 
 setupHLL :: Int -> Int -> B.HLL

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -37,6 +37,7 @@ main = do
       [ bgroup "inserts"
         [ bgroup "foldr"  [ B.benchInserts 10000,              B.benchInserts 50000]
         , bgroup "foldl'" [ B.benchInsertsLStrict 10000,       B.benchInsertsLStrict 50000]
+        , bgroup "batch"  [ B.benchInsertBatched 10000,        B.benchInsertBatched 50000]
         , bgroup "hashes" [ B.benchInsertHashes 10000 hs10k,   B.benchInsertHashes 50000 hs50k]
         ]
       , bgroup "semigroup"
@@ -49,6 +50,7 @@ main = do
       [ bgroup "inserts"
         [ bgroup "foldr"  [ B.benchInserts0 10000,           B.benchInserts0 50000]
         , bgroup "foldl'" [ B.benchInsertsLStrict0 10000,    B.benchInsertsLStrict0 50000]
+        , bgroup "batch"  [ B.benchInsertBatched0 10000,        B.benchInsertBatched0 50000]
         ]
       , bgroup "semigroup"
         [ bgroup "two"    [ B.benchSemigroupTwo0 10000 hll03 hll04, B.benchSemigroupTwo0 50000 hll05 hll06]

--- a/hyperloglogplus.cabal
+++ b/hyperloglogplus.cabal
@@ -75,6 +75,7 @@ benchmark hyperloglogplus-benchmark
     -- Copied from library dependencies
     , base                      >= 4.7       && < 5
     , semigroups                >= 0.18      && < 1
+    , murmur-hash               >= 0.1       && < 0.2
 
   other-modules:
     Data.HyperLogLogPlus.Benchmarks

--- a/hyperloglogplus.cabal
+++ b/hyperloglogplus.cabal
@@ -31,8 +31,8 @@ library
   build-depends:
       base                      >= 4.7       && < 5
     , bits                      >= 0.2       && < 1
-    , vector                    >= 0.11      && < 0.12
-    , containers                >= 0.5       && < 0.6
+    , vector                    >= 0.11      && < 0.13
+    , containers                >= 0.5       && < 0.7
     , semigroups                >= 0.18      && < 1
     , murmur-hash               >= 0.1       && < 0.2
 
@@ -51,12 +51,15 @@ test-suite hyperloglogplus-test
 
   build-depends:
       hyperloglogplus
-    , HUnit                     >= 1.3       && < 1.4
-    , tasty                     >= 0.11      && < 0.12
-    , tasty-hunit               >= 0.9       && < 0.10
+    , HUnit                     >= 1.3       && < 1.7
+    , tasty                     >= 0.11      && < 1.5
+    , tasty-hunit               >= 0.9       && < 0.11
     -- Copied from library dependencies
     , base                      >= 4.7       && < 5
     , semigroups                >= 0.18      && < 1
+
+  other-modules:
+    Data.HyperLogLogPlus.Tests
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
 
@@ -68,8 +71,10 @@ benchmark hyperloglogplus-benchmark
 
   build-depends:
       hyperloglogplus
-    , criterion                 >= 1.1.0.0   && < 1.2.0.0
+    , criterion                 >= 1.1.0.0   && < 1.6.0.0
     -- Copied from library dependencies
     , base                      >= 4.7       && < 5
     , semigroups                >= 0.18      && < 1
 
+  other-modules:
+    Data.HyperLogLogPlus.Benchmarks

--- a/src/Data/HyperLogLogPlus.hs
+++ b/src/Data/HyperLogLogPlus.hs
@@ -4,6 +4,8 @@ module Data.HyperLogLogPlus
   , size
   , insert
   , insertHash
+  , batchInsert
+  , batchInsertHash
   , intersection
   , cast
   ) where

--- a/src/Data/HyperLogLogPlus/Config.hs
+++ b/src/Data/HyperLogLogPlus/Config.hs
@@ -10,6 +10,7 @@ module Data.HyperLogLogPlus.Config
   ) where
 
 import qualified Data.Vector as DV
+import qualified Data.Vector.Unboxed as UV
 
 -- | Min HLL precision
 minP :: Integer
@@ -21,7 +22,7 @@ maxP = 18
 
 -- | Number of buckets for given HLL precision
 numBuckets :: Integer -> Int
-numBuckets p = 2 ^ (fromIntegral p)
+numBuckets p = 2 ^ (fromIntegral p :: Int)
 
 -- | Returns an estimate of an integral term in the
 -- computation of the HLL size.
@@ -34,15 +35,15 @@ alpha m  = 0.7213 / (1.0 + (1.079 / (fromIntegral m)))
 -- | These are the thresholds of cardinality that represent
 -- a transition from LINEARCOUNTING to the bias-corrected
 -- estimates
-thresholds :: DV.Vector Double
-thresholds = DV.fromList [10, 20, 40, 80, 220, 400, 900, 1800, 3100, 6500, 11500, 20000, 50000, 120000, 350000]
+thresholds :: UV.Vector Double
+thresholds = UV.fromList [10, 20, 40, 80, 220, 400, 900, 1800, 3100, 6500, 11500, 20000, 50000, 120000, 350000]
 
 -- | These data are empirical estimates of given cardinalities at
 -- particular precisions, used for bias estimation.
 --
   -- These data come from http://goo.gl/iU8Ig
-rawEstimateData :: DV.Vector (DV.Vector Double)
-rawEstimateData = DV.fromList . map DV.fromList $
+rawEstimateData :: DV.Vector (UV.Vector Double)
+rawEstimateData = DV.fromList . map UV.fromList $
   [
      -- precision 4
      [ 11.0, 11.717, 12.207, 12.7896, 13.2882, 13.8204, 14.3772, 14.9342, 15.5202, 16.161, 16.7722, 17.4636, 18.0396, 18.6766, 19.3566, 20.0454, 20.7936, 21.4856, 22.2666, 22.9946, 23.766, 24.4692, 25.3638, 26.0764, 26.7864, 27.7602, 28.4814, 29.433, 30.2926, 31.0664, 31.9996, 32.7956, 33.5366, 34.5894, 35.5738, 36.2698, 37.3682, 38.0544, 39.2342, 40.0108, 40.7966, 41.9298, 42.8704, 43.6358, 44.5194, 45.773, 46.6772, 47.6174, 48.4888, 49.3304, 50.2506, 51.4996, 52.3824, 53.3078, 54.3984, 55.5838, 56.6618, 57.2174, 58.3514, 59.0802, 60.1482, 61.0376, 62.3598, 62.8078, 63.9744, 64.914, 65.781, 67.1806, 68.0594, 68.8446, 69.7928, 70.8248, 71.8324, 72.8598, 73.6246, 74.7014, 75.393, 76.6708, 77.2394 ],
@@ -81,8 +82,8 @@ rawEstimateData = DV.fromList . map DV.fromList $
 -- it is possible to get other bias estimates based on these empirical data.
 --
 --  These data come from http://goo.gl/iU8Ig
-biasData :: DV.Vector (DV.Vector Double)
-biasData = DV.fromList . map DV.fromList $
+biasData :: DV.Vector (UV.Vector Double)
+biasData = DV.fromList . map UV.fromList $
   [
     -- precision 4
     [ 10, 9.717, 9.207, 8.7896, 8.2882, 7.8204, 7.3772, 6.9342, 6.5202, 6.161, 5.7722, 5.4636, 5.0396, 4.6766, 4.3566, 4.0454, 3.7936, 3.4856, 3.2666, 2.9946, 2.766, 2.4692, 2.3638, 2.0764, 1.7864, 1.7602, 1.4814, 1.433, 1.2926, 1.0664, 0.999600000000001, 0.7956, 0.5366, 0.589399999999998, 0.573799999999999, 0.269799999999996, 0.368200000000002, 0.0544000000000011, 0.234200000000001, 0.0108000000000033, -0.203400000000002, -0.0701999999999998, -0.129600000000003, -0.364199999999997, -0.480600000000003, -0.226999999999997, -0.322800000000001, -0.382599999999996, -0.511200000000002, -0.669600000000003, -0.749400000000001, -0.500399999999999, -0.617600000000003, -0.6922, -0.601599999999998, -0.416200000000003, -0.338200000000001, -0.782600000000002, -0.648600000000002, -0.919800000000002, -0.851799999999997, -0.962400000000002, -0.6402, -1.1922, -1.0256, -1.086, -1.21899999999999, -0.819400000000002, -0.940600000000003, -1.1554, -1.2072, -1.1752, -1.16759999999999, -1.14019999999999, -1.3754, -1.29859999999999, -1.607, -1.3292, -1.7606 ],

--- a/src/Data/HyperLogLogPlus/Type.hs
+++ b/src/Data/HyperLogLogPlus/Type.hs
@@ -25,8 +25,8 @@ import           Data.HyperLogLogPlus.Config
 import           Data.Set                    (Set)
 import qualified Data.Set                    as Set
 
-import           Data.Vector                 ((!))
 import qualified Data.Vector                 as DV
+import           Data.Vector.Unboxed         ((!))
 import qualified Data.Vector.Unboxed         as V
 import qualified Data.Vector.Unboxed.Mutable as MV
 
@@ -160,17 +160,17 @@ estimatedSize hll@(HyperLogLogPlus rank _)
 -- on empirical results.
 estimatedBias :: Double -> Integer -> Double
 estimatedBias e p
-  | e <= DV.head red = DV.head bd
-  | e >  DV.last red = 0.0
+  | e <= V.head red = V.head bd
+  | e >  V.last red = 0.0
   | otherwise        = case idx of
                          Just j -> (slope * e) + intercept
                            where slope = (bd ! (j +1) - bd ! j) / (red ! (j + 1) - red ! j)
                                  intercept = bd ! (j + 1) - slope * red ! (j + 1)
                          Nothing -> 0.0
   where i = fromIntegral $ p - minP
-        red = rawEstimateData ! i
-        bd = biasData ! i
-        idx = V.find (\x -> red ! x < e && e < red ! (x + 1)) $ V.enumFromN 0 (DV.length red - 2)
+        red = rawEstimateData DV.! i  :: V.Vector Double
+        bd = biasData DV.! i          :: V.Vector Double
+        idx = V.find (\x -> red ! x < e && e < red ! (x + 1)) $ V.enumFromN 0 (V.length red - 2)
 {-#INLINE estimatedBias #-}
 
 -- | Returns an estimate of the size of the intersection

--- a/src/Data/HyperLogLogPlus/Type.hs
+++ b/src/Data/HyperLogLogPlus/Type.hs
@@ -77,8 +77,8 @@ import           GHC.Int
 -- >>> intersection $ [(foldr insert mempty [1 .. 15000] ::  HLL), (foldr insert mempty [12000 .. 20000] :: HLL)]
 -- 3100
 data HyperLogLogPlus (p :: Nat) (k :: Nat) = HyperLogLogPlus
-  { hllRank   :: V.Vector Int8
-  , hllMinSet :: Set Hash64
+  { hllRank   :: !(V.Vector Int8)
+  , hllMinSet :: !(Set Hash64)
   } deriving (Eq)
 
 type role HyperLogLogPlus nominal nominal
@@ -145,7 +145,7 @@ estimatedSize hll@(HyperLogLogPlus rank _)
         q =  fromIntegral nb
         nz = fromIntegral . V.length . V.filter (==0) $ rank
         s = V.sum . V.map (\r -> 2.0 ^^ (negate r)) $ rank
-        ae = (alpha nb) * (q ^ 2) * (1.0 / s)
+        ae = (alpha nb) * (q ^ (2 :: Int)) * (1.0 / s)
         e | ae < 5 * q = ae - estimatedBias ae (fromIntegral p)
           | otherwise  = ae
         h | nz > 0     = q * log (q / nz)
@@ -177,7 +177,7 @@ intersection :: forall p k . (KnownNat p, KnownNat k) => [HyperLogLogPlus p k] -
 intersection hs
   | null hs                        = 0
   | any (\hll -> size hll == 0) hs = 0
-  | otherwise                      = round $ ((fromIntegral r) / (fromIntegral n)) * (fromIntegral ts)
+  | otherwise                      = round $ ((fromIntegral r :: Double) / (fromIntegral n)) * (fromIntegral ts)
     where k = natVal (Proxy :: Proxy k)
           u = Set.unions $ map hllMinSet hs
           ts = size $ foldl1 (<>) hs

--- a/src/Data/HyperLogLogPlus/Type.hs
+++ b/src/Data/HyperLogLogPlus/Type.hs
@@ -84,10 +84,12 @@ data HyperLogLogPlus (p :: Nat) (k :: Nat) = HyperLogLogPlus
 type role HyperLogLogPlus nominal nominal
 
 instance (KnownNat k) => Semigroup (HyperLogLogPlus p k) where
-  (HyperLogLogPlus ar ah) <> (HyperLogLogPlus br bh) = HyperLogLogPlus (V.zipWith max ar br) (iterate Set.deleteMax u !! n)
+  (HyperLogLogPlus ar ah) <> (HyperLogLogPlus br bh) = HyperLogLogPlus (V.zipWith max ar br) (delNMax n u)
     where k = fromIntegral $ natVal (Proxy :: Proxy k)
           u = Set.union ah bh
           n = max 0 (Set.size u - k)
+          delNMax 0 s = s
+          delNMax x s = delNMax (x-1) (Set.deleteMax s)
   {-# INLINE (<>) #-}
 
 instance (KnownNat p, KnownNat k, 4 <= p, p <= 18) => Monoid (HyperLogLogPlus p k) where

--- a/test/Data/HyperLogLogPlus/Tests.hs
+++ b/test/Data/HyperLogLogPlus/Tests.hs
@@ -18,6 +18,7 @@ tests = testGroup "Data.HyperLogLogPlus"
     [ testCase "testMempty" testMempty
     , testCase "testSmallSet" testSmallSet
     , testCase "testBigSet" testBigSet
+    , testCase "testBatchInsert" testBatchInsert
     , testCase "testSemigroup" testSemigroup
     , testCase "testIntersection" testIntersection
     , testCase "testUpcastP" testUpcastP
@@ -37,6 +38,11 @@ testSmallSet = assertBool "" $ size (foldr insert mempty (gen [1 .. 1234]) :: HL
 testBigSet :: Assertion
 testBigSet = assertBool "" $ 49000 < n && n < 51000
   where n = size (foldr insert mempty (gen [1 .. 50000]) :: HLL)
+
+testBatchInsert :: Assertion
+testBatchInsert =
+    let xs = gen [1 .. 1234]
+    in assertBool "" $ size (foldr insert mempty xs :: HLL) == size (batchInsert xs (mempty :: HLL))
 
 testSemigroup :: Assertion
 testSemigroup = assertBool "" $ 49000 < n && n < 51000


### PR DESCRIPTION
Optimizations:
- Strict fields make foldr almost as fast as foldl'.
- Batch inserts yield 1.5x speedup.
- Batch inserts when minhash is not used (k=0) yield 8x speedup.

Non-optimizations:
- Changing some vectors to Unboxed, but didn't result in noticable speedup. Kept them Unboxed still.
- Checked Storable vector performance, no difference.

Upper bounds were liberally bumped to let build in my env, should be benign change.